### PR TITLE
Changed PORT on Server, Added 400 codes to Routes

### DIFF
--- a/BE/index.js
+++ b/BE/index.js
@@ -19,7 +19,7 @@ server.use("/api/restricted", restrictedRoutes);
 
 server.use(errorHandler);
 
-const port = 6000;
+const port = 5000;
 server.listen(port, function() {
 	console.log(`\n === Web API Listening on http://localhost:${port}===`);
 });

--- a/BE/routes/authRoutes.js
+++ b/BE/routes/authRoutes.js
@@ -17,7 +17,7 @@ router.post('/register', function(req, res, next) {
   let { username, password } = req.body;
 
   if (!username || !password)
-    return res.json({
+    return res.status(400).json({
       error: true,
       message: 'Please provide a Username, Password'
     });
@@ -34,14 +34,14 @@ router.post('/register', function(req, res, next) {
         token
       });
     })
-    .catch(next);
+    .catch(err => res.status(400).json({error:true, message:'Username is already taken'}));
 });
 
 router.post('/login', function(req, res, next) {
   let { username, password } = req.body;
 
   if (!username || !password)
-    return res.json({
+    return res.status(400).json({
       error: true,
       message: 'Please provide a Username and Password'
     });
@@ -60,7 +60,7 @@ router.post('/login', function(req, res, next) {
           token
         });
       } else {
-        return res.json({
+        return res.status(404).json({
           error: true,
           message: 'Invalid Login Info'
         });

--- a/BE/routes/protectedRoutes.js
+++ b/BE/routes/protectedRoutes.js
@@ -68,7 +68,7 @@ function protected(req, res, next) {
     jwt.verify(token, secret, (err, decodedToken) => {
       if (err) {
         console.log(err);
-        return res.json({
+        return res.status(401).json({
           error: true,
           message: 'You are not authorized to see this data'
         });
@@ -78,7 +78,7 @@ function protected(req, res, next) {
       }
     });
   } else {
-    return res
+    return res.status(400)
       .json({
         error: true,
         message: 'No token provided'


### PR DESCRIPTION
When taking the Sprint Challenge, the Server on PORT 6000 was throwing an UNSAFE Connection error.  Changing the PORT to 5000 resolved this issue.

When registering the same username several times, the server was responding with status 200 on all end points.  I changed the error handling to 400, 401, and 404 in the appropriate places.